### PR TITLE
Added sub-command support and corrected function argument handling (major update)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,20 +11,32 @@ Yash is a C++11 header-only minimal shell for embedded devices.
 ```cpp
 #include <Yash.h>
 
-void i2c(const std::vector<std::string>& args) {
-    printf("i2c command called with %lu args\n", args.size());
+void i2cRead(const std::vector<std::string>& args) {
+    printf("i2cRead(%s, %s, %s)\n", args.at(0).c_str(), args.at(1).c_str(), args.at(2).c_str());
 }
 
-void gpio(const std::vector<std::string>& args) {
-    printf("gpio command called with %lu args\n", args.size());
+void i2cWrite(const std::vector<std::string>& args) {
+    printf("i2cWrite(%s, %s, %s)\n", args.at(0).c_str(), args.at(1).c_str(), args.at(2).c_str());
+}
+
+void info(const std::vector<std::string>& args) {
+    std::ignore = args;
+    printf("info()\n");
+}
+
+void version(const std::vector<std::string>& args) {
+    std::ignore = args;
+    printf("version()\n");
 }
 
 int main() {
     Yash::Yash yash;
     yash.setPrint([&](const char* str) { printf("%s", str); });
     yash.setPrompt("$ ");
-    yash.addCommand("i2c", "I2C read/write", [&](const auto& args) { i2c(args); });
-    yash.addCommand("gpio", "GPIO read/write", [&](const auto& args) { gpio(args); });
+    yash.addCommand("i2c", "read", "I2C read <addr> <reg> <bytes>", [&](const auto& args) { i2cRead(args); }, 3);
+    yash.addCommand("i2c", "write", "I2C write <addr> <reg> <value>", [&](const auto& args) { i2cWrite(args); }, 3);
+    yash.addCommand("info", "System info", [&](const auto& args) { info(args); });
+    yash.addCommand("version", "Build version", [&](const auto& args) { version(args); });
 
     while (true)
         yash.setCharacter(getch());

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![build](https://github.com/bang-olufsen/yash/actions/workflows/build.yml/badge.svg)](https://github.com/bang-olufsen/yash/actions/workflows/build.yml) [![coveralls](https://coveralls.io/repos/github/bang-olufsen/yash/badge.svg?branch=main)](https://coveralls.io/github/bang-olufsen/yash?branch=main) [![codeql](https://github.com/bang-olufsen/yash/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/bang-olufsen/yash/actions/workflows/codeql-analysis.yml) [![lgtm](https://img.shields.io/lgtm/grade/cpp/g/bang-olufsen/yash.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/bang-olufsen/yash/context:cpp) [![codefactor](https://www.codefactor.io/repository/github/bang-olufsen/yash/badge)](https://www.codefactor.io/repository/github/bang-olufsen/yash) [![license](https://img.shields.io/badge/license-MIT_License-blue.svg?style=flat)](LICENSE)
 
-Yash is a C++11 header-only minimal shell for embedded devices.
+Yash is a C++11 header-only minimal shell for embedded devices with support for command completion.
 
 ![](https://raw.githubusercontent.com/bang-olufsen/yash/main/src/example/example.gif)
 
@@ -19,11 +19,11 @@ void i2cWrite(const std::vector<std::string>& args) {
     printf("i2cWrite(%s, %s, %s)\n", args.at(0).c_str(), args.at(1).c_str(), args.at(2).c_str());
 }
 
-void info([[maybe_unused]] const std::vector<std::string>& args) {
+void info(const std::vector<std::string>&) {
     printf("info()\n");
 }
 
-void version([[maybe_unused]] const std::vector<std::string>& args) {
+void version(const std::vector<std::string>&) {
     printf("version()\n");
 }
 

--- a/README.md
+++ b/README.md
@@ -19,13 +19,11 @@ void i2cWrite(const std::vector<std::string>& args) {
     printf("i2cWrite(%s, %s, %s)\n", args.at(0).c_str(), args.at(1).c_str(), args.at(2).c_str());
 }
 
-void info(const std::vector<std::string>& args) {
-    std::ignore = args;
+void info([[maybe_unused]] const std::vector<std::string>& args) {
     printf("info()\n");
 }
 
-void version(const std::vector<std::string>& args) {
-    std::ignore = args;
+void version([[maybe_unused]] const std::vector<std::string>& args) {
     printf("version()\n");
 }
 

--- a/include/Yash.h
+++ b/include/Yash.h
@@ -240,10 +240,23 @@ private:
                     else
                         descriptions.emplace(command, description);
                 }
+            } else {
+                std::string firstCommand;
+                for (const auto& [command, description] : descriptions) {
+                    std::ignore = description;
+                    if (firstCommand.empty())
+                        firstCommand = command.substr(0, command.find_first_of(s_commandDelimiter));
+                    if (firstCommand != command.substr(0, command.find_first_of(s_commandDelimiter))) {
+                        firstCommand.clear();
+                        break;
+                    }
+                }
+                if (!firstCommand.empty())
+                    m_command = firstCommand + s_commandDelimiter;
             }
         }
 
-        print(s_clearLine);
+        print("\r\n");
         printCommands(descriptions);
     }
 

--- a/include/Yash.h
+++ b/include/Yash.h
@@ -1,4 +1,25 @@
-// Copyright 2021 - Bang & Olufsen a/s
+// The MIT License (MIT)
+
+// Copyright (c) 2021 Bang & Olufsen a/s
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 #pragma once
 
 #include <cstdarg>

--- a/include/Yash.h
+++ b/include/Yash.h
@@ -221,13 +221,17 @@ private:
     {
         std::map<std::string, std::string> descriptions;
         for (const auto& [command, description] : m_descriptions) {
-            if (m_command.length() && !command.compare(0, m_command.length(), m_command))
+            if (!m_command.empty() && !std::memcmp(command.data(), m_command.data(), std::min(m_command.length(), command.length())))
                 descriptions.emplace(command, description);
         }
 
-        if (descriptions.size() == 1 && autoComplete)
-            m_command = descriptions.begin()->first + s_commandDelimiter;
-        else {
+        if (descriptions.size() == 1 && autoComplete) {
+            auto completeCommand = descriptions.begin()->first + s_commandDelimiter;
+            if (m_command != completeCommand) {
+                m_command = completeCommand;
+                return;
+            }
+        } else {
             if (descriptions.empty()) {
                 for (const auto& [command, description] : m_descriptions) {
                     auto position = command.find(s_commandDelimiter);
@@ -237,9 +241,10 @@ private:
                         descriptions.emplace(command, description);
                 }
             }
-            print(s_clearLine);
-            printCommands(descriptions);
         }
+
+        print(s_clearLine);
+        printCommands(descriptions);
     }
 
     static constexpr const char* s_clearLine = "\033[2K\033[100D";

--- a/include/Yash.h
+++ b/include/Yash.h
@@ -199,9 +199,12 @@ private:
                     token = std::strtok(nullptr, s_commandDelimiter);
                 }
                 function(m_args);
+                print(m_prompt.c_str());
+                return;
             }
         }
 
+        printCommands(m_descriptions);
         print(m_prompt.c_str());
     }
 

--- a/include/Yash.h
+++ b/include/Yash.h
@@ -71,7 +71,7 @@ public:
     void addCommand(const std::string& command, const std::string& subCommand, const std::string& description, YashFunction function, size_t requiredArguments = 0)
     {
         auto fullCommand = subCommand.empty() ? command : command + s_commandDelimiter + subCommand;
-        m_functions.emplace(fullCommand, CommandFunction(description, function, requiredArguments));
+        m_functions.emplace(fullCommand, Function(description, function, requiredArguments));
     }
 
     /// @brief Removes a command from the shell
@@ -175,8 +175,8 @@ private:
         LeftBracket
     };
 
-    struct CommandFunction {
-        CommandFunction(std::string description, YashFunction function, size_t requiredArguments) 
+    struct Function {
+        Function(std::string description, YashFunction function, size_t requiredArguments) 
             : m_description(description)
             , m_function(function)
             , m_requiredArguments(requiredArguments) {}
@@ -279,7 +279,7 @@ private:
     static constexpr const char* s_clearScreen = "\033[2J\x1B[H";
     static constexpr const char* s_clearCharacter = "\033[1D \033[1D";
     static constexpr const char* s_commandDelimiter = " ";
-    std::map<std::string, CommandFunction> m_functions;
+    std::map<std::string, Function> m_functions;
     std::vector<std::string> m_commands;
     std::vector<std::string>::const_iterator m_commandsIndex;
     std::string m_command;

--- a/include/Yash.h
+++ b/include/Yash.h
@@ -178,7 +178,7 @@ private:
     void runCommand()
     {
         m_args.clear();
-        for (auto& [command, function] : m_functions) {
+        for (const auto& [command, function] : m_functions) {
             std::ignore = function;
             if (!m_command.compare(0, command.length(), command)) {
                 auto args = m_command.substr(command.length());
@@ -210,17 +210,17 @@ private:
             return std::max(max, desc.first.size());
         }) };
 
-        for (auto const& desc : descriptions) {
-            std::string alignment((maxCommandSize + 2) - desc.first.size(), ' ');
-            auto description { desc.first + alignment + desc.second + "\r\n" };
-            print(description.c_str());
+        for (const auto& [command, description] : descriptions) {
+            std::string alignment((maxCommandSize + 2) - command.size(), ' ');
+            auto line { command + alignment + description + "\r\n" };
+            print(line.c_str());
         }
     }
 
     void printDescriptions(bool autoComplete = false)
     {
         std::map<std::string, std::string> descriptions;
-        for (auto& [command, description] : m_descriptions) {
+        for (const auto& [command, description] : m_descriptions) {
             if (m_command.length() && !command.compare(0, m_command.length(), m_command))
                 descriptions.emplace(command, description);
         }
@@ -229,7 +229,7 @@ private:
             m_command = descriptions.begin()->first + s_commandDelimiter;
         else {
             if (descriptions.empty()) {
-                for (auto& [command, description] : m_descriptions) {
+                for (const auto& [command, description] : m_descriptions) {
                     auto position = command.find(s_commandDelimiter);
                     if (position != std::string::npos)
                         descriptions.emplace(command.substr(0, position), "Commands");

--- a/include/Yash.h
+++ b/include/Yash.h
@@ -57,16 +57,34 @@ public:
     /// @param function A YashFunction to be called when the command is executed
     void addCommand(const std::string& command, const std::string& description, YashFunction function)
     {
-        m_functions.emplace(command, function);
-        m_descriptions.emplace(command, description);
+        addCommand(command, "", description, function);
+    }
+
+    /// @brief Adds a command with a sub command to the shell
+    /// @param command A string with the name of the command
+    /// @param command A string with the name of the sub command
+    /// @param description A string with the command description
+    /// @param function A YashFunction to be called when the command is executed
+    void addCommand(const std::string& command, const std::string& subCommand, const std::string& description, YashFunction function)
+    {
+        m_functions.emplace(command + s_commandDelimiter + subCommand, function);
+        m_descriptions.emplace(command + s_commandDelimiter + subCommand, description);
     }
 
     /// @brief Removes a command from the shell
     /// @param command A string with the name of the command
     void removeCommand(const std::string& command)
     {
-        m_functions.erase(command);
-        m_descriptions.erase(command);
+        removeCommand(command, "");
+    }
+
+    /// @brief Removes a command from the shell
+    /// @param command A string with the name of the command
+    /// @param command A string with the name of the sub command
+    void removeCommand(const std::string& command, const std::string& subCommand)
+    {
+        m_functions.erase(command + s_commandDelimiter + subCommand);
+        m_descriptions.erase(command + s_commandDelimiter + subCommand);
     }
 
     /// @brief Sets a received character on the shell
@@ -227,6 +245,7 @@ private:
     static constexpr const char* s_clearLine = "\033[2K\033[100D";
     static constexpr const char* s_clearScreen = "\033[2J\x1B[H";
     static constexpr const char* s_clearCharacter = "\033[1D \033[1D";
+    static constexpr const char* s_commandDelimiter = " ";
     std::map<std::string, YashFunction> m_functions;
     std::map<std::string, std::string> m_descriptions;
     std::vector<std::string> m_commands;

--- a/include/Yash.h
+++ b/include/Yash.h
@@ -122,8 +122,8 @@ public:
             }
             break;
         case Tab:
-            if (m_command.length())
-                printDescriptions();
+            printDescriptions(true);
+            printCommand();
             break;
         case Esc:
             m_ctrlState = CtrlState::Esc;
@@ -177,6 +177,8 @@ private:
 
     void runCommand()
     {
+        printf("CMD: %s\n", m_command.c_str());
+        m_args.clear();
         for (auto& [command, function] : m_functions) {
             std::ignore = function;
             if (!m_command.compare(0, command.length(), command)) {
@@ -193,6 +195,7 @@ private:
         }
 
         printDescriptions();
+        print(m_prompt.c_str());
     }
 
     void printCommand()
@@ -215,19 +218,22 @@ private:
         }
     }
 
-    void printDescriptions()
+    void printDescriptions(bool complete = false)
     {
+        bool commandFound = false;
         std::map<std::string, std::string> descriptions;
         for (auto& [command, description] : m_descriptions) {
-            if (!command.compare(0, m_command.length(), m_command))
+            if (m_command.length() && !command.compare(0, m_command.length(), m_command)) {
                 descriptions.emplace(command, description);
+                commandFound = true;
+            }
         }
 
-        if (descriptions.size() == 1) {
+        if (descriptions.size() == 1 && complete)
             m_command = descriptions.begin()->first + ' ';
-            printCommand();
-        } else {
-            if (descriptions.empty()) {
+        else {
+            if (!commandFound) {
+                descriptions.clear();
                 for (auto& [command, description] : m_descriptions) {
                     auto position = command.find(s_commandDelimiter);
                     if (position != std::string::npos)
@@ -238,7 +244,6 @@ private:
             }
             print(s_clearLine);
             printCommands(descriptions);
-            descriptions.empty() ? print(m_prompt.c_str()) : printCommand();
         }
     }
 

--- a/include/Yash.h
+++ b/include/Yash.h
@@ -231,7 +231,7 @@ private:
                 descriptions.emplace(command, description);
         }
 
-        if (descriptions.size() == 1 && autoComplete) {
+        if ((descriptions.size() == 1) && autoComplete) {
             auto completeCommand = descriptions.begin()->first + s_commandDelimiter;
             if (m_command.size() < completeCommand.size()) {
                 m_command = completeCommand;
@@ -258,7 +258,7 @@ private:
                     }
                 }
 
-                if (!firstCommand.empty())
+                if (!firstCommand.empty() && (firstCommand.size() > m_command.size()))
                     m_command = firstCommand + s_commandDelimiter;
             }
         }

--- a/include/Yash.h
+++ b/include/Yash.h
@@ -177,7 +177,6 @@ private:
 
     void runCommand()
     {
-        printf("CMD: %s\n", m_command.c_str());
         m_args.clear();
         for (auto& [command, function] : m_functions) {
             std::ignore = function;
@@ -218,22 +217,18 @@ private:
         }
     }
 
-    void printDescriptions(bool complete = false)
+    void printDescriptions(bool autoComplete = false)
     {
-        bool commandFound = false;
         std::map<std::string, std::string> descriptions;
         for (auto& [command, description] : m_descriptions) {
-            if (m_command.length() && !command.compare(0, m_command.length(), m_command)) {
+            if (m_command.length() && !command.compare(0, m_command.length(), m_command))
                 descriptions.emplace(command, description);
-                commandFound = true;
-            }
         }
 
-        if (descriptions.size() == 1 && complete)
-            m_command = descriptions.begin()->first + ' ';
+        if (descriptions.size() == 1 && autoComplete)
+            m_command = descriptions.begin()->first + s_commandDelimiter;
         else {
-            if (!commandFound) {
-                descriptions.clear();
+            if (descriptions.empty()) {
                 for (auto& [command, description] : m_descriptions) {
                     auto position = command.find(s_commandDelimiter);
                     if (position != std::string::npos)

--- a/src/example/example.cpp
+++ b/src/example/example.cpp
@@ -4,8 +4,12 @@
 
 #include <Yash.h>
 
-void i2c(const std::vector<std::string>& args) {
-    printf("i2c command called with %lu args\n", args.size());
+void i2cRead(const std::vector<std::string>& args) {
+    printf("i2cRead command called with %lu args\n", args.size());
+}
+
+void i2cWrite(const std::vector<std::string>& args) {
+    printf("i2cWrite command called with %lu args\n", args.size());
 }
 
 void info(const std::vector<std::string>& args) {
@@ -20,7 +24,8 @@ int main() {
     Yash::Yash yash;
     yash.setPrint([&](const char* str) { printf("%s", str); });
     yash.setPrompt("$ ");
-    yash.addCommand("i2c", "I2C read/write", [&](const auto& args) { i2c(args); });
+    yash.addCommand("i2c", "read", "I2C read <bytes>", [&](const auto& args) { i2cRead(args); });
+    yash.addCommand("i2c", "write", "I2C write <bytes>", [&](const auto& args) { i2cWrite(args); });
     yash.addCommand("info", "System info", [&](const auto& args) { info(args); });
     yash.addCommand("gpio", "GPIO read/write", [&](const auto& args) { gpio(args); });
 

--- a/src/example/example.cpp
+++ b/src/example/example.cpp
@@ -24,8 +24,8 @@ int main() {
     Yash::Yash yash;
     yash.setPrint([&](const char* str) { printf("%s", str); });
     yash.setPrompt("$ ");
-    yash.addCommand("i2c", "read", "I2C read <register> <bytes>", [&](const auto& args) { i2cRead(args); });
-    yash.addCommand("i2c", "write", "I2C write <register> <bytes>", [&](const auto& args) { i2cWrite(args); });
+    yash.addCommand("i2c", "read", "I2C read <addr> <reg> <bytes>", [&](const auto& args) { i2cRead(args); }, 3);
+    yash.addCommand("i2c", "write", "I2C write <addr> <reg> <value>", [&](const auto& args) { i2cWrite(args); }, 3);
     yash.addCommand("info", "System info", [&](const auto& args) { info(args); });
     yash.addCommand("version", "Build version", [&](const auto& args) { version(args); });
 

--- a/src/example/example.cpp
+++ b/src/example/example.cpp
@@ -12,11 +12,11 @@ void i2cWrite(const std::vector<std::string>& args) {
     printf("i2cWrite(%s, %s, %s)\n", args.at(0).c_str(), args.at(1).c_str(), args.at(2).c_str());
 }
 
-void info([[maybe_unused]] const std::vector<std::string>& args) {
+void info(const std::vector<std::string>&) {
     printf("info()\n");
 }
 
-void version([[maybe_unused]] const std::vector<std::string>& args) {
+void version(const std::vector<std::string>&) {
     printf("version()\n");
 }
 

--- a/src/example/example.cpp
+++ b/src/example/example.cpp
@@ -12,13 +12,11 @@ void i2cWrite(const std::vector<std::string>& args) {
     printf("i2cWrite(%s, %s, %s)\n", args.at(0).c_str(), args.at(1).c_str(), args.at(2).c_str());
 }
 
-void info(const std::vector<std::string>& args) {
-    std::ignore = args;
+void info([[maybe_unused]] const std::vector<std::string>& args) {
     printf("info()\n");
 }
 
-void version(const std::vector<std::string>& args) {
-    std::ignore = args;
+void version([[maybe_unused]] const std::vector<std::string>& args) {
     printf("version()\n");
 }
 

--- a/src/example/example.cpp
+++ b/src/example/example.cpp
@@ -5,19 +5,21 @@
 #include <Yash.h>
 
 void i2cRead(const std::vector<std::string>& args) {
-    printf("i2c read command called with %lu arguments\n", args.size());
+    printf("i2cRead(%s, %s, %s)\n", args.at(0).c_str(), args.at(1).c_str(), args.at(2).c_str());
 }
 
 void i2cWrite(const std::vector<std::string>& args) {
-    printf("i2c write command called with %lu arguments\n", args.size());
+    printf("i2cWrite(%s, %s, %s)\n", args.at(0).c_str(), args.at(1).c_str(), args.at(2).c_str());
 }
 
 void info(const std::vector<std::string>& args) {
-    printf("info command called with %lu arguments\n", args.size());
+    std::ignore = args;
+    printf("info()\n");
 }
 
 void version(const std::vector<std::string>& args) {
-    printf("version command called with %lu arguments\n", args.size());
+    std::ignore = args;
+    printf("version()\n");
 }
 
 int main() {

--- a/src/example/example.cpp
+++ b/src/example/example.cpp
@@ -5,29 +5,29 @@
 #include <Yash.h>
 
 void i2cRead(const std::vector<std::string>& args) {
-    printf("i2cRead command called with %lu args\n", args.size());
+    printf("i2c read command called with %lu arguments\n", args.size());
 }
 
 void i2cWrite(const std::vector<std::string>& args) {
-    printf("i2cWrite command called with %lu args\n", args.size());
+    printf("i2c write command called with %lu arguments\n", args.size());
 }
 
 void info(const std::vector<std::string>& args) {
-    printf("info command called with %lu args\n", args.size());
+    printf("info command called with %lu arguments\n", args.size());
 }
 
-void gpio(const std::vector<std::string>& args) {
-    printf("gpio command called with %lu args\n", args.size());
+void version(const std::vector<std::string>& args) {
+    printf("version command called with %lu arguments\n", args.size());
 }
 
 int main() {
     Yash::Yash yash;
     yash.setPrint([&](const char* str) { printf("%s", str); });
     yash.setPrompt("$ ");
-    yash.addCommand("i2c", "read", "I2C read <bytes>", [&](const auto& args) { i2cRead(args); });
-    yash.addCommand("i2c", "write", "I2C write <bytes>", [&](const auto& args) { i2cWrite(args); });
+    yash.addCommand("i2c", "read", "I2C read <register> <bytes>", [&](const auto& args) { i2cRead(args); });
+    yash.addCommand("i2c", "write", "I2C write <register> <bytes>", [&](const auto& args) { i2cWrite(args); });
     yash.addCommand("info", "System info", [&](const auto& args) { info(args); });
-    yash.addCommand("gpio", "GPIO read/write", [&](const auto& args) { gpio(args); });
+    yash.addCommand("version", "Build version", [&](const auto& args) { version(args); });
 
     while (true)
         yash.setCharacter(getch());

--- a/test/TestYash.cpp
+++ b/test/TestYash.cpp
@@ -15,18 +15,18 @@ MOCK_FUNCTION(second, 1, void(const std::vector<std::string>& args));
 
 void SetupHistoryPreconditions(Yash::Yash& yash)
 {
-    std::string secondCommand = "proximity";
-    std::string secondDescription = "proximity functions";
+    std::string secondCommand = "version";
+    std::string secondDescription = "Build info";
     yash.addCommand(secondCommand, secondDescription, &second);
 
     MOCK_EXPECT(print);
 
     MOCK_EXPECT(i2c).once();
-    for (char& character : "i2c\n"s)
+    for (char& character : "i2c read 1 2 3\n"s)
         yash.setCharacter(character);
 
     MOCK_EXPECT(second).once();
-    for (char& character : "proximity\n"s)
+    for (char& character : "version\n"s)
         yash.setCharacter(character);
 }
 } // namespace
@@ -37,11 +37,12 @@ TEST_CASE("Yash test")
     Yash::Yash yash;
     std::string prompt = "$ ";
     std::string command = "i2c";
-    std::string description = "i2c read/write functions";
+    std::string subCommand = "read";
+    std::string description = "I2C read <addr> <reg> <bytes>";
 
     yash.setPrint(print);
     yash.setPrompt(prompt);
-    yash.addCommand(command, description, &i2c);
+    yash.addCommand(command, subCommand, description, &i2c, 3);
 
     SECTION("Test setPrompt function")
     {
@@ -65,7 +66,7 @@ TEST_CASE("Yash test")
     SECTION("Test setCharacter function with 'i2' input")
     {
         std::string testCommand = "i2\n";
-        std::string help = command + "  " + description + "\r\n";
+        std::string help = command + " " + subCommand + "  " + description + "\r\n";
 
         MOCK_EXPECT(print).with("");
         MOCK_EXPECT(print).with("i");
@@ -85,7 +86,7 @@ TEST_CASE("Yash test")
         MOCK_EXPECT(print).once().in(seq).with("i");
         MOCK_EXPECT(print).once().in(seq).with(mock::any);
         MOCK_EXPECT(print).once().in(seq).with(prompt.c_str());
-        MOCK_EXPECT(print).once().in(seq).with("i2c ");
+        MOCK_EXPECT(print).once().in(seq).with("i2c read ");
         yash.setCharacter('i');
         yash.setCharacter(Yash::Yash::Tab);
     }
@@ -99,8 +100,8 @@ TEST_CASE("Yash test")
         mock::sequence seq;
         MOCK_EXPECT(print).once().in(seq).with("i");
         MOCK_EXPECT(print).once().in(seq).with(mock::any);
-        MOCK_EXPECT(print).once().in(seq).with(command + "   " + description + "\r\n");
-        MOCK_EXPECT(print).once().in(seq).with(secondCommand + "  " + secondDescription + "\r\n");
+        MOCK_EXPECT(print).once().in(seq).with(command + " " + subCommand + "  " + description + "\r\n");
+        MOCK_EXPECT(print).once().in(seq).with(secondCommand + "      " + secondDescription + "\r\n");
         MOCK_EXPECT(print).once().in(seq).with(mock::any);
         MOCK_EXPECT(print).once().in(seq).with(prompt.c_str());
         MOCK_EXPECT(print).once().in(seq).with("i");
@@ -108,34 +109,34 @@ TEST_CASE("Yash test")
         yash.setCharacter(Yash::Yash::Tab);
     }
 
-    SECTION("Test setCharacter function with 'i2c' input")
+    SECTION("Test setCharacter function with 'i2c read 1 2 3' input")
     {
-        std::string testCommand = "i2c\n";
+        std::string testCommand = "i2c read 1 2 3\n";
 
-        MOCK_EXPECT(i2c).once().with(std::vector<std::string> { "i2c" });
+        MOCK_EXPECT(i2c).once().with(std::vector<std::string> { "1", "2", "3" });
         MOCK_EXPECT(print);
 
         for (char& character : testCommand)
             yash.setCharacter(character);
     }
 
-    SECTION("Test setCharacter function with 'i2c read' input")
+    SECTION("Test setCharacter function with 'i2c read 1 2 3' input")
     {
         std::string testCommand { GENERATE(as<std::string>(),
-            "i2c read\n",
-            "i2c read \n",
-            "i2c read  \n") };
+            "i2c read 1 2 3\n",
+            "i2c read 1 2 3 \n",
+            "i2c read 1 2 3  \n") };
 
-        MOCK_EXPECT(i2c).once().with(std::vector<std::string> { "i2c", "read" });
+        MOCK_EXPECT(i2c).once().with(std::vector<std::string> { "1", "2", "3" });
         MOCK_EXPECT(print);
 
         for (char& character : testCommand)
             yash.setCharacter(character);
     }
 
-    SECTION("Test setCharacter function with 'i2c' and end of text (clear) character input")
+    SECTION("Test setCharacter function with 'i2c read 1 2 3' and end of text (clear) character input")
     {
-        std::string testCommand = "i2c";
+        std::string testCommand = "i2c read 1 2 3";
 
         MOCK_EXPECT(print);
 
@@ -148,9 +149,9 @@ TEST_CASE("Yash test")
         CHECK(yash.m_command.empty());
     }
 
-    SECTION("Test setCharacter function with 'i2c1' and backspace character input")
+    SECTION("Test setCharacter function with 'i2c read 1 2 3' and backspace character input")
     {
-        std::string testCommand = "i2c1\b\n";
+        std::string testCommand = "i2c read 1 2 3\b\n";
 
         // Expect the i2c function to be called as the character 1 will be deleted
         MOCK_EXPECT(i2c);
@@ -236,6 +237,7 @@ TEST_CASE("Yash test")
         yash.setCharacter('\n');
     }
 
+#if 0
     SECTION("Test setCharacter - History overflow")
     {
         MOCK_EXPECT(print);
@@ -270,10 +272,11 @@ TEST_CASE("Yash test")
         CHECK_FALSE(yash.m_functions.empty());
         CHECK_FALSE(yash.m_descriptions.empty());
 
-        yash.removeCommand(command);
+        yash.removeCommand(command + " " + subCommand);
         CHECK(yash.m_functions.empty());
         CHECK(yash.m_descriptions.empty());
     }
+#endif
 
     mock::verify();
     mock::reset();

--- a/test/TestYash.cpp
+++ b/test/TestYash.cpp
@@ -237,13 +237,12 @@ TEST_CASE("Yash test")
         yash.setCharacter('\n');
     }
 
-#if 0
     SECTION("Test setCharacter - History overflow")
     {
         MOCK_EXPECT(print);
 
         MOCK_EXPECT(i2c).once();
-        for (char& character : "i2c\n"s)
+        for (char& character : "i2c read 1 2 3\n"s)
             yash.setCharacter(character);
 
         // Fill up the history queue so the i2c command overflows
@@ -276,7 +275,6 @@ TEST_CASE("Yash test")
         CHECK(yash.m_functions.empty());
         CHECK(yash.m_descriptions.empty());
     }
-#endif
 
     mock::verify();
     mock::reset();

--- a/test/TestYash.cpp
+++ b/test/TestYash.cpp
@@ -52,7 +52,6 @@ TEST_CASE("Yash test")
     SECTION("Test addCommand function")
     {
         CHECK_FALSE(yash.m_functions.empty());
-        CHECK_FALSE(yash.m_descriptions.empty());
     }
 
     SECTION("Test setCharacter function with line feed input")
@@ -269,11 +268,9 @@ TEST_CASE("Yash test")
         // Try to remove a non-existing command
         yash.removeCommand("i2");
         CHECK_FALSE(yash.m_functions.empty());
-        CHECK_FALSE(yash.m_descriptions.empty());
 
         yash.removeCommand(command + " " + subCommand);
         CHECK(yash.m_functions.empty());
-        CHECK(yash.m_descriptions.empty());
     }
 
     mock::verify();


### PR DESCRIPTION
With these changes there is now full command completion support 🕺🏻 and a hopefully better function handling 👍🏻

Commands are now specified as a single command or a command with a sub-command. When specifying a function the number of minimum required arguments can be specified so this does not need to be checked in the function (more than the required arguments is still seen as valid). In case of too few arguments the function description is printed. Hereby no additional handling is required in the added function as the arguments have been validated 🍻

This is a major update and will unfortunately break the current handling - sorry. Hopefully it is for the better 🤞🏻

The changes can be tested local with `./build.sh` and `.build-x86/yash-example`