### PR TITLE
bumping Catch2 to version v2.13.7

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -16,7 +16,7 @@ ExternalProject_Add(
 ExternalProject_Add(
     Catch2
     GIT_REPOSITORY https://github.com/catchorg/Catch2
-    GIT_TAG v2.13.4
+    GIT_TAG v2.13.7
     SOURCE_DIR ../src/external/Catch2
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""


### PR DESCRIPTION
I suggest we bump catch2 to to v2.13.7 or newer since older versions yields a compilation error due to change in glibc.
https://github.com/catchorg/Catch2/issues/2178