### PR TITLE
Changed usage of std::vector to std::list

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,17 +11,25 @@ Yash is a C++17 header-only minimal shell for embedded devices with support for 
 ```cpp
 #include <Yash.h>
 
-void i2cRead(const std::vector<std::string>& args)
+void i2cRead(Yash::Arguments args)
 {
-    printf("i2cRead(%s, %s, %s)\n", args.at(0).c_str(), args.at(1).c_str(), args.at(2).c_str());
+    printf("i2cRead(%s, %s, %s)\n",
+           std::next(args.begin(), 0)->c_str(),
+           std::next(args.begin(), 1)->c_str(),
+           std::next(args.begin(), 2)->c_str()
+    );
 }
 
-void i2cWrite(const std::vector<std::string>& args)
+void i2cWrite(Yash::Arguments args)
 {
-    printf("i2cWrite(%s, %s, %s)\n", args.at(0).c_str(), args.at(1).c_str(), args.at(2).c_str());
+    printf("i2cWrite(%s, %s, %s)\n",
+           std::next(args.begin(), 0)->c_str(),
+           std::next(args.begin(), 1)->c_str(),
+           std::next(args.begin(), 2)->c_str()
+    );
 }
 
-void info(const std::vector<std::string>&)
+void info(Yash::Arguments)
 {
     printf("info()\n");
 }

--- a/README.md
+++ b/README.md
@@ -13,20 +13,19 @@ Yash is a C++17 header-only minimal shell for embedded devices with support for 
 
 void i2cRead(Yash::Arguments args)
 {
+
     printf("i2cRead(%s, %s, %s)\n",
-           std::next(args.begin(), 0)->c_str(),
-           std::next(args.begin(), 1)->c_str(),
-           std::next(args.begin(), 2)->c_str()
-    );
+        std::next(args.begin(), 0)->c_str(),
+        std::next(args.begin(), 1)->c_str(),
+        std::next(args.begin(), 2)->c_str());
 }
 
 void i2cWrite(Yash::Arguments args)
 {
     printf("i2cWrite(%s, %s, %s)\n",
-           std::next(args.begin(), 0)->c_str(),
-           std::next(args.begin(), 1)->c_str(),
-           std::next(args.begin(), 2)->c_str()
-    );
+        std::next(args.begin(), 0)->c_str(),
+        std::next(args.begin(), 1)->c_str(),
+        std::next(args.begin(), 2)->c_str());
 }
 
 void info(Yash::Arguments)

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -3,20 +3,27 @@
 
 #include <Yash.h>
 #include <con.h>
-#include <stdlib.h>
+#include <cstdlib>
 
-void i2cRead(const std::vector<std::string>& args)
-{
-    printf("i2cRead(%s, %s, %s)\n", args.at(0).c_str(), args.at(1).c_str(), args.at(2).c_str());
+
+void i2cRead(Yash::Arguments args) {
+
+    printf("i2cRead(%s, %s, %s)\n",
+           std::next(args.begin(), 0)->c_str(),
+           std::next(args.begin(), 1)->c_str(),
+           std::next(args.begin(), 2)->c_str()
+    );
 }
 
-void i2cWrite(const std::vector<std::string>& args)
-{
-    printf("i2cWrite(%s, %s, %s)\n", args.at(0).c_str(), args.at(1).c_str(), args.at(2).c_str());
+void i2cWrite(Yash::Arguments args) {
+    printf("i2cWrite(%s, %s, %s)\n",
+           std::next(args.begin(), 0)->c_str(),
+           std::next(args.begin(), 1)->c_str(),
+           std::next(args.begin(), 2)->c_str()
+    );
 }
 
-void info(const std::vector<std::string>&)
-{
+void info(Yash::Arguments) {
     printf("info()\n");
 }
 

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -6,24 +6,25 @@
 #include <cstdlib>
 
 
-void i2cRead(Yash::Arguments args) {
+void i2cRead(Yash::Arguments args)
+{
 
     printf("i2cRead(%s, %s, %s)\n",
-           std::next(args.begin(), 0)->c_str(),
-           std::next(args.begin(), 1)->c_str(),
-           std::next(args.begin(), 2)->c_str()
-    );
+        std::next(args.begin(), 0)->c_str(),
+        std::next(args.begin(), 1)->c_str(),
+        std::next(args.begin(), 2)->c_str());
 }
 
-void i2cWrite(Yash::Arguments args) {
+void i2cWrite(Yash::Arguments args)
+{
     printf("i2cWrite(%s, %s, %s)\n",
-           std::next(args.begin(), 0)->c_str(),
-           std::next(args.begin(), 1)->c_str(),
-           std::next(args.begin(), 2)->c_str()
-    );
+        std::next(args.begin(), 0)->c_str(),
+        std::next(args.begin(), 1)->c_str(),
+        std::next(args.begin(), 2)->c_str());
 }
 
-void info(Yash::Arguments) {
+void info(Yash::Arguments)
+{
     printf("info()\n");
 }
 

--- a/include/Yash.h
+++ b/include/Yash.h
@@ -7,11 +7,11 @@
 #include <cstdio>
 #include <cstring>
 #include <functional>
+#include <list>
 #include <map>
 #include <numeric>
 #include <string>
 #include <string_view>
-#include <list>
 
 namespace Yash {
 

--- a/include/Yash.h
+++ b/include/Yash.h
@@ -11,11 +11,12 @@
 #include <numeric>
 #include <string>
 #include <string_view>
-#include <vector>
+#include <list>
 
 namespace Yash {
 
-typedef void (*CommandFunction)(const std::vector<std::string>&);
+typedef const std::list<std::string>& Arguments;
+typedef void (*CommandFunction)(Yash::Arguments);
 
 struct Command {
     std::string_view name;
@@ -277,7 +278,7 @@ private:
 
     void runCommand()
     {
-        std::vector<std::string> arguments;
+        std::list<std::string> arguments;
         for (const auto& command : m_commands) {
             if (!m_command.compare(0, command.name.size(), command.name)) {
                 auto args = m_command.substr(command.name.size());
@@ -380,8 +381,8 @@ private:
     CtrlState m_ctrlState { CtrlState::None };
     const std::array<Command, TCommandArraySize>& m_commands;
     std::function<void(const char*)> m_printFunction;
-    std::vector<std::string> m_commandHistory;
-    std::vector<std::string>::const_iterator m_commandHistoryIndex;
+    std::list<std::string> m_commandHistory;
+    std::list<std::string>::const_iterator m_commandHistoryIndex;
     std::string m_command;
     std::string m_prompt;
     std::string m_ctrlCharacter;

--- a/test/TestYash.cpp
+++ b/test/TestYash.cpp
@@ -5,13 +5,13 @@
 #define private public
 #include "Yash.h"
 
-#define SetupHistoryPreconditions() \
-    MOCK_EXPECT(print); \
-    MOCK_EXPECT(i2c).once(); \
+#define SetupHistoryPreconditions()             \
+    MOCK_EXPECT(print);                         \
+    MOCK_EXPECT(i2c).once();                    \
     for (char& character : "i2c read 1 2 3\n"s) \
-        yash.setCharacter(character); \
-    MOCK_EXPECT(info).once(); \
-    for (char& character : "info\n"s) \
+        yash.setCharacter(character);           \
+    MOCK_EXPECT(info).once();                   \
+    for (char& character : "info\n"s)           \
         yash.setCharacter(character);
 
 using namespace std::string_literals;
@@ -21,9 +21,9 @@ MOCK_FUNCTION(print, 1, void(const char*));
 MOCK_FUNCTION(i2c, 1, void(Yash::Arguments args));
 MOCK_FUNCTION(info, 1, void(Yash::Arguments args));
 
-constexpr const char *s_clearCharacter = "\033[1D \033[1D";
-constexpr const char *s_moveCursorForward = "\033[1C";
-constexpr const char *s_moveCursorBackward = "\033[1D";
+constexpr const char* s_clearCharacter = "\033[1D \033[1D";
+constexpr const char* s_moveCursorForward = "\033[1C";
+constexpr const char* s_moveCursorBackward = "\033[1D";
 } // namespace
 
 
@@ -31,7 +31,7 @@ TEST_CASE("Yash test")
 {
     static constexpr std::array<Yash::Command, 2> commands {
         { { "i2c read", "I2C read <addr> <reg> <bytes>", &i2c, 3 },
-        { "info", "System info", &info, 0 } }
+            { "info", "System info", &info, 0 } }
     };
 
     std::string prompt = "$ ";

--- a/test/TestYash.cpp
+++ b/test/TestYash.cpp
@@ -18,8 +18,8 @@ using namespace std::string_literals;
 
 namespace {
 MOCK_FUNCTION(print, 1, void(const char*));
-MOCK_FUNCTION(i2c, 1, void(const std::vector<std::string>& args));
-MOCK_FUNCTION(info, 1, void(const std::vector<std::string>& args));
+MOCK_FUNCTION(i2c, 1, void(Yash::Arguments args));
+MOCK_FUNCTION(info, 1, void(Yash::Arguments args));
 
 constexpr const char *s_clearCharacter = "\033[1D \033[1D";
 constexpr const char *s_moveCursorForward = "\033[1C";
@@ -128,7 +128,7 @@ TEST_CASE("Yash test")
     {
         std::string testCommand = "i2c read 1 2 3\n";
 
-        MOCK_EXPECT(i2c).once().with(std::vector<std::string> { "1", "2", "3" });
+        MOCK_EXPECT(i2c).once().with(std::list<std::string> { "1", "2", "3" });
         MOCK_EXPECT(print);
 
         for (char& character : testCommand)
@@ -142,7 +142,7 @@ TEST_CASE("Yash test")
             "i2c read 1 2 3 \n",
             "i2c read 1 2 3  \n") };
 
-        MOCK_EXPECT(i2c).once().with(std::vector<std::string> { "1", "2", "3" });
+        MOCK_EXPECT(i2c).once().with(std::list<std::string> { "1", "2", "3" });
         MOCK_EXPECT(print);
 
         for (char& character : testCommand)


### PR DESCRIPTION
This will cause **breaking** changes since std::list does not support random access in argument handling e.g. see example usage.

Changes:
- Replaced usage of `std::vector` with `std::list`
- Typedef'ed prototype for arguments from `std::list<std::string>&` to Yash::Arguments to simplify usage.
- Changed `args.at(0)` to `std::next(args.begin(), 0)` when accessing the args in command callbacks.

Reason for this change is to avoid unnecessary usage of memory when adding new elements to the container. Due to expansion of `std::vector`'s internal memory usage.