### PR TITLE
Use `std::span` as interface containers + some minor improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .vscode/settings.json
 .build*
+.cache*
+compile_commands.json
+Testing*

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![build](https://github.com/bang-olufsen/yash/actions/workflows/build.yml/badge.svg)](https://github.com/bang-olufsen/yash/actions/workflows/build.yml) [![coveralls](https://coveralls.io/repos/github/bang-olufsen/yash/badge.svg?branch=main)](https://coveralls.io/github/bang-olufsen/yash?branch=main) [![codeql](https://github.com/bang-olufsen/yash/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/bang-olufsen/yash/actions/workflows/codeql-analysis.yml) [![lgtm](https://img.shields.io/lgtm/grade/cpp/g/bang-olufsen/yash.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/bang-olufsen/yash/context:cpp) [![license](https://img.shields.io/badge/license-MIT_License-blue.svg?style=flat)](LICENSE)
 
-Yash is a C++17 header-only minimal shell for embedded devices with support for command completion.
+Yash is a C++20 header-only minimal shell for embedded devices with support for command completion.
 
 ![](https://raw.githubusercontent.com/bang-olufsen/yash/main/example/example.gif)
 

--- a/README.md
+++ b/README.md
@@ -11,30 +11,29 @@ Yash is a C++20 header-only minimal shell for embedded devices with support for 
 ```cpp
 #include <Yash.h>
 
-void i2cRead(const std::vector<std::string>& args)
+void i2c(const std::string_view command, Yash::CommandArgs args)
 {
-    printf("i2cRead(%s, %s, %s)\n", args.at(0).c_str(), args.at(1).c_str(), args.at(2).c_str());
+    if (command == "read")
+        printf("i2cRead(%s, %s, %s)\n", args.at(0).data(), args.at(1).data(), args.at(2).data());
+    else if (command == "write")
+        printf("i2cWrite(%s, %s, %s)\n", args.at(0).data(), args.at(1).data(), args.at(2).data());
 }
 
-void i2cWrite(const std::vector<std::string>& args)
-{
-    printf("i2cWrite(%s, %s, %s)\n", args.at(0).c_str(), args.at(1).c_str(), args.at(2).c_str());
-}
-
-void info(const std::vector<std::string>&)
+void info(Yash::CommandArgs /* unused */)
 {
     printf("info()\n");
 }
 
 int main()
 {
-    static constexpr std::array<Yash::Command, 3> commands {
-        { { "i2c read", "I2C read <addr> <reg> <bytes>", [](const auto& args) { i2cRead(args); }, 3 },
-            { "i2c write", "I2C write <addr> <reg> <value>", [](const auto& args) { i2cWrite(args); }, 3 },
-            { "info", "System info", [](const auto& args) { info(args); }, 0 } }
-    };
+    static constexpr Yash::Config config { .maxRequiredArgs = 3, .commandHistorySize = 10 };
+    static constexpr auto commands = std::to_array<Yash::Command>({
+        { "i2c read", "I2C read <addr> <reg> <bytes>", [](Yash::CommandArgs args) { i2c("read", args); }, 3 },
+        { "i2c write", "I2C write <addr> <reg> <value>", [](Yash::Commands args) { i2c("write", args); }, 3 },
+        { "info", "System info", [](const auto args) { info(args); }, 0 }, // OR auto if preffered
+    });
 
-    Yash::Yash<std::size(commands)> yash(commands);
+    Yash::Yash<config, std::size(commands)> yash(commands);
     yash.setPrint([&](const char* str) { printf("%s", str); });
     yash.setPrompt("$ ");
 
@@ -43,5 +42,4 @@ int main()
 
     return 0;
 }
-
 ```

--- a/build.sh
+++ b/build.sh
@@ -13,7 +13,7 @@ make -j "$(nproc)"
 popd
 
 mkdir -p .build-x86; pushd .build-x86
-cmake "$CMAKE_ARGS" -DCMAKE_TOOLCHAIN_FILE=cmake/gcc.cmake ..
+cmake "$CMAKE_ARGS" -DCMAKE_TOOLCHAIN_FILE=cmake/gcc.cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=1 ..
 make -j "$(nproc)"
 
 if [ "$1" = "coverage" ]; then

--- a/cmake/gcc.cmake
+++ b/cmake/gcc.cmake
@@ -20,7 +20,7 @@ set(COMMON_C_FLAGS
 
 set(COMMON_CXX_FLAGS
     ${COMMON_FLAGS}
-    -std=c++17
+    -std=c++20
 )
 
 string(REPLACE ";" " " CMAKE_COMMON_C_FLAGS "${COMMON_C_FLAGS}")

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -2,33 +2,30 @@
 // SPDX-License-Identifier: MIT
 
 #include <Yash.h>
-#include <con.h>
-#include <stdlib.h>
 
-void i2cRead(const std::vector<std::string>& args)
+void i2c(const std::string_view command, Yash::CommandArgs args)
 {
-    printf("i2cRead(%s, %s, %s)\n", args.at(0).c_str(), args.at(1).c_str(), args.at(2).c_str());
+    if (command == "read")
+        printf("i2cRead(%s, %s, %s)\n", args.at(0).data(), args.at(1).data(), args.at(2).data());
+    else if (command == "write")
+        printf("i2cWrite(%s, %s, %s)\n", args.at(0).data(), args.at(1).data(), args.at(2).data());
 }
 
-void i2cWrite(const std::vector<std::string>& args)
-{
-    printf("i2cWrite(%s, %s, %s)\n", args.at(0).c_str(), args.at(1).c_str(), args.at(2).c_str());
-}
-
-void info(const std::vector<std::string>&)
+void info(Yash::CommandArgs /* unused */)
 {
     printf("info()\n");
 }
 
 int main()
 {
-    static constexpr std::array<Yash::Command, 3> commands {
-        { { "i2c read", "I2C read <addr> <reg> <bytes>", [](const auto& args) { i2cRead(args); }, 3 },
-            { "i2c write", "I2C write <addr> <reg> <value>", [](const auto& args) { i2cWrite(args); }, 3 },
-            { "info", "System info", [](const auto& args) { info(args); }, 0 } }
-    };
+    static constexpr Yash::Config config { .maxRequiredArgs = 3, .commandHistorySize = 10 };
+    static constexpr auto commands = std::to_array<Yash::Command>({
+        { "i2c read", "I2C read <addr> <reg> <bytes>", [](Yash::CommandArgs args) { i2c("read", args); }, 3 },
+        { "i2c write", "I2C write <addr> <reg> <value>", [](Yash::Commands args) { i2c("write", args); }, 3 },
+        { "info", "System info", [](const auto args) { info(args); }, 0 }, // OR auto if preffered
+    });
 
-    Yash::Yash<std::size(commands)> yash(commands);
+    Yash::Yash<config, std::size(commands)> yash(commands);
     yash.setPrint([&](const char* str) { printf("%s", str); });
     yash.setPrompt("$ ");
 

--- a/test/TestYash.cpp
+++ b/test/TestYash.cpp
@@ -30,13 +30,11 @@ constexpr const char* s_moveCursorBackward = "\033[1D";
 
 TEST_CASE("Yash test")
 {
-    static constexpr std::array<Yash::Command, 2> commands {
-        {
-            { "i2c read", "I2C read <addr> <reg> <bytes>", &i2c, 3 },
-            { "info", "System info", &info, 0 },
-        }
-    };
     static constexpr Yash::Config config { .maxRequiredArgs = 3, .commandHistorySize = 10 };
+    static constexpr auto commands = std::to_array<Yash::Command>({
+        { "i2c read", "I2C read <addr> <reg> <bytes>", &i2c, 3 },
+        { "info", "System info", &info, 0 },
+    });
 
     std::string prompt = "$ ";
     Yash::Yash<config, std::size(commands)> yash(commands);


### PR DESCRIPTION
See each commit for details :)

Next steps:

1. Remove vector usage for command history
2. Remove map usage for descriptor print

Might implement: auto deduction of arg size based on commands so the buffer is always the exact size it needs to be.