### PR TITLE
Fix segmentation fault on vector reallocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,14 @@ Yash is a C++20 header-only minimal shell for embedded devices with support for 
 
 ```cpp
 #include <Yash.h>
+#include <con.h>
 
 void i2c(const std::string_view command, Yash::CommandArgs args)
 {
     if (command == "read")
-        printf("i2cRead(%s, %s, %s)\n", args.at(0).data(), args.at(1).data(), args.at(2).data());
+        printf("i2cRead(%s, %s, %s)\n", args[0].data(), args[1].data(), args[2].data());
     else if (command == "write")
-        printf("i2cWrite(%s, %s, %s)\n", args.at(0).data(), args.at(1).data(), args.at(2).data());
+        printf("i2cWrite(%s, %s, %s)\n", args[0].data(), args[1].data(), args[2].data());
 }
 
 void info(Yash::CommandArgs /* unused */)
@@ -29,7 +30,7 @@ int main()
     static constexpr Yash::Config config { .maxRequiredArgs = 3, .commandHistorySize = 10 };
     static constexpr auto commands = std::to_array<Yash::Command>({
         { "i2c read", "I2C read <addr> <reg> <bytes>", [](Yash::CommandArgs args) { i2c("read", args); }, 3 },
-        { "i2c write", "I2C write <addr> <reg> <value>", [](Yash::Commands args) { i2c("write", args); }, 3 },
+        { "i2c write", "I2C write <addr> <reg> <value>", [](Yash::CommandArgs args) { i2c("write", args); }, 3 },
         { "info", "System info", [](const auto args) { info(args); }, 0 }, // OR auto if preffered
     });
 

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -2,13 +2,14 @@
 // SPDX-License-Identifier: MIT
 
 #include <Yash.h>
+#include <con.h>
 
 void i2c(const std::string_view command, Yash::CommandArgs args)
 {
     if (command == "read")
-        printf("i2cRead(%s, %s, %s)\n", args.at(0).data(), args.at(1).data(), args.at(2).data());
+        printf("i2cRead(%s, %s, %s)\n", args[0].data(), args[1].data(), args[2].data());
     else if (command == "write")
-        printf("i2cWrite(%s, %s, %s)\n", args.at(0).data(), args.at(1).data(), args.at(2).data());
+        printf("i2cWrite(%s, %s, %s)\n", args[0].data(), args[1].data(), args[2].data());
 }
 
 void info(Yash::CommandArgs /* unused */)
@@ -21,7 +22,7 @@ int main()
     static constexpr Yash::Config config { .maxRequiredArgs = 3, .commandHistorySize = 10 };
     static constexpr auto commands = std::to_array<Yash::Command>({
         { "i2c read", "I2C read <addr> <reg> <bytes>", [](Yash::CommandArgs args) { i2c("read", args); }, 3 },
-        { "i2c write", "I2C write <addr> <reg> <value>", [](Yash::Commands args) { i2c("write", args); }, 3 },
+        { "i2c write", "I2C write <addr> <reg> <value>", [](Yash::CommandArgs args) { i2c("write", args); }, 3 },
         { "info", "System info", [](const auto args) { info(args); }, 0 }, // OR auto if preffered
     });
 

--- a/include/Yash.h
+++ b/include/Yash.h
@@ -7,12 +7,12 @@
 #include <cstdio>
 #include <cstring>
 #include <functional>
+#include <list>
 #include <map>
 #include <numeric>
 #include <span>
 #include <string>
 #include <string_view>
-#include <vector>
 
 namespace Yash {
 
@@ -74,13 +74,16 @@ public:
             print("\r\n");
             if (!m_command.empty()) {
                 runCommand();
-                m_commandHistory.push_back(m_command);
 
-                if (m_commandHistory.size() > m_commandHistorySize)
-                    m_commandHistory.erase(m_commandHistory.begin());
+                // Only add to history if so is allowed
+                if (TConfig.commandHistorySize > 0) {
+                    if (m_commandHistory.size() >= m_commandHistorySize)
+                        m_commandHistory.erase(m_commandHistory.begin());
 
-                m_command.clear();
-                m_commandHistoryIndex = m_commandHistory.end();
+                    m_commandHistory.push_back(m_command);
+                    m_command.clear();
+                    m_commandHistoryIndex = m_commandHistory.end();
+                }
             } else
                 print(m_prompt.c_str());
             m_position = m_command.length();
@@ -394,10 +397,10 @@ private:
     CommandSpan m_commands;
     std::array<std::string_view, TConfig.maxRequiredArgs> m_commandArgs;
     std::function<void(const char*)> m_printFunction;
-    std::vector<std::string> m_commandHistory;
-    std::vector<std::string>::const_iterator m_commandHistoryIndex;
+    std::list<std::string> m_commandHistory;
+    std::list<std::string>::const_iterator m_commandHistoryIndex;
     std::string m_command;
-    std::string m_prompt;
+    std::string m_prompt { "Yash$ " };
     std::string m_ctrlCharacter;
     size_t m_position { 0 };
     size_t m_commandHistorySize { 0 };


### PR DESCRIPTION
Fixes double allocation for vector as element was inserted before deleted.
Also fixes dangling iterators when vector reallocates.

Would be better with a fixed sized circle buffer - will be for another day. 
`std::list` should be alright for memory constrained devices as memory is no longer stored contiguously. 