### PR TITLE
Reduce allocations when printing commands

### DIFF
--- a/include/Yash.h
+++ b/include/Yash.h
@@ -3,8 +3,6 @@
 
 #pragma once
 
-#include <cstdarg>
-#include <cstdio>
 #include <cstring>
 #include <functional>
 #include <list>

--- a/include/Yash.h
+++ b/include/Yash.h
@@ -227,8 +227,6 @@ public:
                                     m_position++;
                                 }
                                 break;
-                            default:
-                                break;
                             }
                         } else
                             return; // check the next ctrl character

--- a/include/Yash.h
+++ b/include/Yash.h
@@ -400,19 +400,24 @@ private:
 
     void printAllCommands()
     {
-        std::optional<std::string_view> optView;
+        std::list<std::string_view> groupedCommands;
         for (const auto& command : m_commands) {
+            // If command name contains a delimiter it means that we can group those
             auto position = command.name.find_first_of(s_commandDelimiter);
             if (position != std::string::npos) {
                 auto subView = command.name.substr(0, position);
-                if (optView.has_value() && optView.value() == subView)
+                if (std::find(groupedCommands.begin(), groupedCommands.end(), subView) != groupedCommands.end())
                     continue;
 
+                groupedCommands.push_back(subView);
+
+                // Group commands like: i2c  I2c commands
                 auto firstCommandView = command.name.substr(0, position);
                 std::string firstCommand = std::string { firstCommandView.begin(), firstCommandView.end() } + " commands";
                 firstCommand[0] = toupper(firstCommand[0]);
-                printNameAndDescription(subView, firstCommand, m_allCommandsSizeAlignment);
-                optView = subView;
+
+                // We have to do the string conversion as the subspan_view is not terminated
+                printNameAndDescription(std::string { subView }, firstCommand, m_allCommandsSizeAlignment);
             } else {
                 printNameAndDescription(command.name, command.description, m_allCommandsSizeAlignment);
             }

--- a/test/TestYash.cpp
+++ b/test/TestYash.cpp
@@ -58,15 +58,19 @@ TEST_CASE("Yash test")
     SECTION("Test setCharacter function with 'i2' input")
     {
         std::string testCommand = "i2\n";
-        std::string help = "i2c read  I2C read <addr> <reg> <bytes>\r\n";
 
-        MOCK_EXPECT(print).with("");
-        MOCK_EXPECT(print).with("i");
-        MOCK_EXPECT(print).with("2");
-        MOCK_EXPECT(print).with("\r\n");
+        mock::sequence seq;
+        MOCK_EXPECT(print).once().in(seq).with("i");
+        MOCK_EXPECT(print).once().in(seq).with("2");
+        MOCK_EXPECT(print).once().in(seq).with("\r\n");
+
+        // Print i2c command + alignment
+        MOCK_EXPECT(print).once().in(seq).with(commands.at(0).name);
+        MOCK_EXPECT(print).exactly(2).in(seq).with(" ");
+        MOCK_EXPECT(print).once().in(seq).with(commands.at(0).description);
+        MOCK_EXPECT(print).once().in(seq).with("\r\n");
+
         MOCK_EXPECT(print).with(prompt.c_str());
-        // Expect the help menu to be printed as the command is wrong
-        MOCK_EXPECT(print).with(help.c_str());
 
         for (char& character : testCommand)
             yash.setCharacter(character);
@@ -90,11 +94,23 @@ TEST_CASE("Yash test")
         mock::sequence seq;
         MOCK_EXPECT(print).once().in(seq).with("i");
         MOCK_EXPECT(print).once().in(seq).with(mock::any);
-        MOCK_EXPECT(print).once().in(seq).with("i2c read  I2C read <addr> <reg> <bytes>\r\n");
-        MOCK_EXPECT(print).once().in(seq).with("info      System info\r\n");
+
+        // Print i2c command + alignment
+        MOCK_EXPECT(print).once().in(seq).with(commands.at(0).name);
+        MOCK_EXPECT(print).exactly(2).in(seq).with(" ");
+        MOCK_EXPECT(print).once().in(seq).with(commands.at(0).description);
+        MOCK_EXPECT(print).once().in(seq).with("\r\n");
+
+        // Print info command + alignment
+        MOCK_EXPECT(print).once().in(seq).with(commands.at(1).name);
+        MOCK_EXPECT(print).exactly(6).in(seq).with(" ");
+        MOCK_EXPECT(print).once().in(seq).with(commands.at(1).description);
+        MOCK_EXPECT(print).once().in(seq).with("\r\n");
+
         MOCK_EXPECT(print).once().in(seq).with(mock::any);
         MOCK_EXPECT(print).once().in(seq).with(prompt.c_str());
         MOCK_EXPECT(print).once().in(seq).with("i");
+
         yash.setCharacter('i');
         yash.setCharacter(yash.Tab);
     }
@@ -167,10 +183,10 @@ TEST_CASE("Yash test")
         for (char& character : testCommand)
             yash.setCharacter(character);
 
-        CHECK_FALSE(yash.m_command.empty());
+        CHECK_FALSE(yash.m_inputCommand.empty());
 
         yash.setCharacter(yash.EndOfText);
-        CHECK(yash.m_command.empty());
+        CHECK(yash.m_inputCommand.empty());
     }
 
     SECTION("Test setCharacter function with 'i2c read 1 2 3' and backspace character input")
@@ -434,7 +450,7 @@ TEST_CASE("Yash test")
             mock::reset();
         }
 
-        CHECK(yash.m_command == "ic");
+        CHECK(yash.m_inputCommand == "ic");
     }
 
     SECTION("Test setCharacter function with 'i2c' with home and end character input to change cursor position")

--- a/test/TestYash.cpp
+++ b/test/TestYash.cpp
@@ -33,6 +33,7 @@ TEST_CASE("Yash test")
     static constexpr Yash::Config config { .maxRequiredArgs = 3, .commandHistorySize = 10 };
     static constexpr auto commands = std::to_array<Yash::Command>({
         { "i2c read", "I2C read <addr> <reg> <bytes>", &i2c, 3 },
+        { "i2c write", "I2C write <addr> <reg> <bytes>", &i2c, 3 },
         { "info", "System info", &info, 0 },
     });
 
@@ -64,10 +65,16 @@ TEST_CASE("Yash test")
         MOCK_EXPECT(print).once().in(seq).with("2");
         MOCK_EXPECT(print).once().in(seq).with("\r\n");
 
-        // Print i2c command + alignment
+        // Print i2c read command + alignment
         MOCK_EXPECT(print).once().in(seq).with(commands.at(0).name);
-        MOCK_EXPECT(print).exactly(2).in(seq).with(" ");
+        MOCK_EXPECT(print).exactly(3).in(seq).with(" ");
         MOCK_EXPECT(print).once().in(seq).with(commands.at(0).description);
+        MOCK_EXPECT(print).once().in(seq).with("\r\n");
+
+        // Print i2c write command + alignment
+        MOCK_EXPECT(print).once().in(seq).with(commands.at(1).name);
+        MOCK_EXPECT(print).exactly(2).in(seq).with(" ");
+        MOCK_EXPECT(print).once().in(seq).with(commands.at(1).description);
         MOCK_EXPECT(print).once().in(seq).with("\r\n");
 
         MOCK_EXPECT(print).with(prompt.c_str());
@@ -76,16 +83,22 @@ TEST_CASE("Yash test")
             yash.setCharacter(character);
     }
 
-    SECTION("Test setCharacter function with 'i2' + TAB input")
+    SECTION("Test setCharacter function with 'i2c r' + TAB input")
     {
         mock::sequence seq;
         MOCK_EXPECT(print).once().in(seq).with("i");
         MOCK_EXPECT(print).once().in(seq).with("2");
+        MOCK_EXPECT(print).once().in(seq).with("c");
+        MOCK_EXPECT(print).once().in(seq).with(" ");
+        MOCK_EXPECT(print).once().in(seq).with("r");
         MOCK_EXPECT(print).once().in(seq).with(mock::any);
         MOCK_EXPECT(print).once().in(seq).with(prompt.c_str());
         MOCK_EXPECT(print).once().in(seq).with("i2c read ");
         yash.setCharacter('i');
         yash.setCharacter('2');
+        yash.setCharacter('c');
+        yash.setCharacter(' ');
+        yash.setCharacter('r');
         yash.setCharacter(yash.Tab);
     }
 
@@ -95,16 +108,22 @@ TEST_CASE("Yash test")
         MOCK_EXPECT(print).once().in(seq).with("i");
         MOCK_EXPECT(print).once().in(seq).with(mock::any);
 
-        // Print i2c command + alignment
+        // Print i2c read command + alignment
         MOCK_EXPECT(print).once().in(seq).with(commands.at(0).name);
-        MOCK_EXPECT(print).exactly(2).in(seq).with(" ");
+        MOCK_EXPECT(print).exactly(3).in(seq).with(" ");
         MOCK_EXPECT(print).once().in(seq).with(commands.at(0).description);
         MOCK_EXPECT(print).once().in(seq).with("\r\n");
 
-        // Print info command + alignment
+        // Print i2c write command + alignment
         MOCK_EXPECT(print).once().in(seq).with(commands.at(1).name);
-        MOCK_EXPECT(print).exactly(6).in(seq).with(" ");
+        MOCK_EXPECT(print).exactly(2).in(seq).with(" ");
         MOCK_EXPECT(print).once().in(seq).with(commands.at(1).description);
+        MOCK_EXPECT(print).once().in(seq).with("\r\n");
+
+        // Print info command + alignment
+        MOCK_EXPECT(print).once().in(seq).with(commands.at(2).name);
+        MOCK_EXPECT(print).exactly(7).in(seq).with(" ");
+        MOCK_EXPECT(print).once().in(seq).with(commands.at(2).description);
         MOCK_EXPECT(print).once().in(seq).with("\r\n");
 
         MOCK_EXPECT(print).once().in(seq).with(mock::any);


### PR DESCRIPTION
Have removed a fair bit of allocations. 

Some bullet points:
We could also remove the allocation from grouped commands if we want but it'll require a specialized print command.
Also we can remove 81e101304102c8ebb853fc3acb3b0a986c7eb61a if we are okay with commands always having to be grouped in the container for the grouping to work; feature or? :)

A side effect of not using the map; the commands are no longer sorted! It's now the consumer who has to provide the order.
Could add a constexpr sorting helper to operate on the span but it will require that we remove some constness. 

Also did some renaming to make it more clear about what's going on.

Let me know what you think :)

Will clean up history and add commit details based on reviews :+1: 