### PR TITLE
cmake: bump min version to avoid incompatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(yash)
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 add_library(${PROJECT_NAME} INTERFACE)
 target_include_directories(${PROJECT_NAME} INTERFACE include)

--- a/build.sh
+++ b/build.sh
@@ -21,7 +21,7 @@ if [ "$1" = "coverage" ]; then
   ctest --verbose
   lcov -q -c -d . -o test.info 2>/dev/null
   lcov -q -a base.info -a test.info > total.info
-  lcov -q -r total.info "*usr/include/*" "*CMakeFiles*" "*Catch2*" "*turtle*" "*/test/*" "*src/*" -o coverage.info
+  lcov -q -r total.info "*usr/include/*" "*CMakeFiles*" "*Catch2*" "*turtle*" "*/test/*" -o coverage.info
   genhtml -o coverage coverage.info
   echo "Coverage report can be found in $(pwd)/coverage"
 fi

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -1,7 +1,7 @@
 project(external)
 
 include(ExternalProject)
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 ExternalProject_Add(
     turtle

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,4 +3,8 @@ set(MODULE_NAME test-yash)
 add_executable(${MODULE_NAME} TestYash.cpp)
 target_link_libraries(${MODULE_NAME} boost_unit_test_framework catch turtle yash)
 
+target_compile_options(${MODULE_NAME} PUBLIC
+    -DBOOST_BIND_GLOBAL_PLACEHOLDERS
+)
+
 add_test(${MODULE_NAME} ${MODULE_NAME})


### PR DESCRIPTION
Modern cmake will soon remove support for any build system < 3.5. Ensure we're compatible.

```
CMake Deprecation Warning at src/external/yash/CMakeLists.txt:2 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
```